### PR TITLE
Добавить Service Workers

### DIFF
--- a/packages/client/service-worker.js
+++ b/packages/client/service-worker.js
@@ -1,0 +1,81 @@
+// обновляем при новой сборке
+const CACHE_VERSION = 1;
+const CURRENT_CACHE = `cache-${CACHE_VERSION}`;
+
+// что мы изначально хотим закешировать
+const cacheFiles = ['/', '/index.html'];
+
+// при активации нового sw удаляем старый кэш
+self.addEventListener('activate', (evt) => {
+  console.log(`Service worker ${CURRENT_CACHE} activated`);
+  evt.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          if (cacheName !== CURRENT_CACHE) {
+            console.log(`Old service worker ${cacheName} removed`);
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+});
+
+// при усановке мы загружаем в кэш все файлы из массива cacheFiles
+self.addEventListener('install', (evt) =>
+  evt.waitUntil(
+    caches
+      .open(CURRENT_CACHE)
+      .then((cache) => {
+        return cache.addAll(cacheFiles);
+      })
+      .then(
+        () => {
+          console.log(`Service worker ${CURRENT_CACHE} has been updated.`);
+        },
+        (err) => {
+          console.warn(`Failed to update ${CURRENT_CACHE}. ${err}`);
+        }
+      )
+  )
+);
+
+// запрос ресурса из сети с таймаутом
+const fromNetwork = (request, timeout) =>
+  new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(reject, timeout);
+    fetch(request)
+      .then((fetchResponse) => {
+        clearTimeout(timeoutId);
+        return update(request, fetchResponse);
+      })
+      .then(resolve)
+      .catch(reject);
+  });
+
+// запрос ресурса из кэша
+const fromCache = (request) =>
+  caches.open(CURRENT_CACHE).then((cache) => cache.match(request));
+
+// добавить новый ресурс в кэш
+const update = (request, fetchResponse) =>
+  caches.open(CURRENT_CACHE).then((cache) => {
+    cache.put(request, fetchResponse.clone());
+    return fetchResponse;
+  });
+
+// пытамся загрузить ресурс из сети, если не получается, то из кэша
+self.addEventListener('fetch', (ev) => {
+  // не обрабатываем не GET запросы
+  if (ev.request.method !== 'GET') {
+    return;
+  }
+
+  ev.respondWith(
+    fromNetwork(ev.request, 5000).catch(() => {
+      console.log(`Fetching request for: ${ev.request.url} from cache`);
+      return fromCache(ev.request);
+    })
+  );
+});

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom'
 import router from './router'
 import { ThemeProvider, CssBaseline } from '@mui/material'
 import theme from './utils/scripts/theme'
+import { register } from './utils/service-worker'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
@@ -13,3 +14,5 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     </ThemeProvider>
   </React.StrictMode>
 )
+
+register('/service-worker.js')

--- a/packages/client/src/utils/service-worker/index.ts
+++ b/packages/client/src/utils/service-worker/index.ts
@@ -1,0 +1,17 @@
+export const register = async (swUrl: string) => {
+  if (!import.meta.env.PROD) {
+    console.log('Service worker is not registered in development mode.')
+    return
+  }
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', async () => {
+      try {
+        await navigator.serviceWorker.register(swUrl)
+      } catch (e) {
+        console.error(`Registration of service worker failed with ${e}`)
+      }
+    })
+  } else {
+    console.log('Service workers are not supported.')
+  }
+}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import dotenv from 'dotenv'
+import { buildSync } from 'esbuild'
+import { join } from 'node:path'
 dotenv.config()
 
 // https://vitejs.dev/config/
@@ -11,5 +13,20 @@ export default defineConfig({
   define: {
     __SERVER_PORT__: process.env.SERVER_PORT,
   },
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: 'build-sw',
+      apply: 'build', // вызывать плагин только при сборке
+      enforce: 'post', // вызывать после Vite core plugins
+      transformIndexHtml() {
+        buildSync({
+          minify: true,
+          bundle: true,
+          entryPoints: [join(process.cwd(), 'service-worker.js')],
+          outfile: join(process.cwd(), 'dist', 'service-worker.js'),
+        })
+      },
+    },
+  ],
 })


### PR DESCRIPTION
Сервис-воркер регистрируется только в production режиме. Чтобы протестировать локально, нужно выполнить 
`npm run build` и `npm run preview`. 

При первой загрузке приложения все запрашиваемые ресурсы, в том числе запросы к api (кроме POST) сохраняются в кеше. 
Таким образом, если интернет пропадает, то они будут подгружаться из кеша.
Так же они будут подгружаться из кеша, если запрос в сеть будем выполняться дольше таймаута (5 секунд)

Добавлен плагин, который минифицирует файл сервис-воркера и добавляет в сборку.
